### PR TITLE
Add 'order by' in dequeue query.

### DIFF
--- a/q4pg.py
+++ b/q4pg.py
@@ -115,6 +115,7 @@ select * from %s
     then pg_try_advisory_lock(tableoid::int, id)
     else false
   end
+  order by id
   limit 1;
 """ % (n,)
         self.list_sql = """


### PR DESCRIPTION
https://github.com/smihica/py-q4pg/blob/master/q4pg.py#L112-L118

I think this dequeue query  destroy the order of the enqueue.
So I added 'order by' .
