### PR TITLE
Issues/rcin 3330 multiprocess access control

### DIFF
--- a/q4pg.py
+++ b/q4pg.py
@@ -124,7 +124,8 @@ select * from %s
     else false
   end
   order by id
-  limit 1;
+  limit 1
+  for update;
 """ % (n,)
         self.list_sql = """
 select * from %s

--- a/test.py
+++ b/test.py
@@ -405,10 +405,11 @@ def multiprocess_tasks():
     [j.join() for j in jobs]
 
     processed_data = set()
-    qsize = queue.qsize()
+    qsize = 0
     while not queue.empty():
         item = queue.get()
         data = item.get('data')
+        qsize += 1
         if data in processed_data:
             raise Exception("failed multiprocess_tasks - data %s has been processed already" % (data, ))
         processed_data.add(item.get('data'))


### PR DESCRIPTION
- prevent multiple processes from accessing the same data in the queue simultaneously by using "for update"